### PR TITLE
fix: CategoryServiceでOpenAPI型に明示的に変換するよう修正

### DIFF
--- a/src/server/services/category-service.ts
+++ b/src/server/services/category-service.ts
@@ -1,19 +1,35 @@
 import { Category } from '@prisma/client';
+import { components } from '../../types/api';
 import { ICategoryRepository } from '../repositories/interfaces/i-category-repository';
 
+// OpenAPI スキーマの Category 型
+type APICategory = components['schemas']['Category'];
+
 export interface ICategoryService {
-  getAllCategories(): Promise<Category[]>;
-  getCategoryById(id: string): Promise<Category | null>;
+  getAllCategories(): Promise<APICategory[]>;
+  getCategoryById(id: string): Promise<APICategory | null>;
 }
 
 export class CategoryService implements ICategoryService {
   constructor(private categoryRepository: ICategoryRepository) {}
 
-  async getAllCategories(): Promise<Category[]> {
-    return this.categoryRepository.findAll();
+  async getAllCategories(): Promise<APICategory[]> {
+    const categories = await this.categoryRepository.findAll();
+    return categories.map(category => this.convertToAPICategory(category));
   }
 
-  async getCategoryById(id: string): Promise<Category | null> {
-    return this.categoryRepository.findById(id);
+  async getCategoryById(id: string): Promise<APICategory | null> {
+    const category = await this.categoryRepository.findById(id);
+    if (!category) {
+      return null;
+    }
+    return this.convertToAPICategory(category);
+  }
+
+  private convertToAPICategory(category: Category): APICategory {
+    return {
+      id: category.id,
+      name: category.name,
+    };
   }
 }


### PR DESCRIPTION
## Summary
- CategoryServiceでPrismaの型をそのまま返している部分を、OpenAPIの型に明示的に変換するよう修正
- アーキテクチャの一貫性を保つため、RecipeServiceと同様の型変換パターンを適用

## Test plan
- [ ] CategoryService の型変換が正しく動作することを確認
- [ ] /api/categories エンドポイントのレスポンスがOpenAPI仕様に準拠していることを確認
- [ ] 既存のテストが引き続き成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)